### PR TITLE
Bump parity-scale-codec and ethereum-types versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = { version = "0.10", default-features = false, features = ["rlp"] }
+ethereum-types = { version = "0.11", default-features = false, features = ["rlp"] }
 rlp = { version = "0.5", default-features = false }
-codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"], optional = true }
+codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 rlp-derive = "0.1"
 sha3 = { version = "0.9", default-features = false }


### PR DESCRIPTION
This bumps `parity-scale-codec` and `ethereum-types` versions.

This is needed so that `frontier` can have a consistent dependency on parity-scale-codec.