### PR TITLE
Tidy up typed transaction implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum"
-version = "0.8.0"
+version = "0.9.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "Core block and transaction types for Ethereum."

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,7 +1,9 @@
-use crate::{util::ordered_trie_root, Header, PartialHeader, TransactionV0, TransactionV1, TransactionV2};
+use crate::{
+	util::ordered_trie_root, Header, PartialHeader, TransactionV0, TransactionV1, TransactionV2,
+};
 use alloc::vec::Vec;
 use ethereum_types::H256;
-use rlp::{Encodable, Decodable, RlpStream, Rlp, DecoderError};
+use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use sha3::{Digest, Keccak256};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -34,11 +36,7 @@ impl<T: Decodable> Decodable for Block<T> {
 
 impl<T: Encodable> Block<T> {
 	#[must_use]
-	pub fn new(
-		partial_header: PartialHeader,
-		transactions: Vec<T>,
-		ommers: Vec<Header>,
-	) -> Self {
+	pub fn new(partial_header: PartialHeader, transactions: Vec<T>, ommers: Vec<Header>) -> Self {
 		let ommers_hash =
 			H256::from_slice(Keccak256::digest(&rlp::encode_list(&ommers)[..]).as_slice());
 		let transactions_root =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,8 @@ pub mod util;
 type Bytes = alloc::vec::Vec<u8>;
 
 pub use account::Account;
-pub use block::Block;
+pub use block::*;
 pub use header::{Header, PartialHeader};
 pub use log::Log;
 pub use receipt::Receipt;
-pub use transaction::{
-	Transaction, TransactionAction, TransactionMessage, TransactionSignature, TransactionV0,
-	TransactionV1,
-};
+pub use transaction::*;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -636,12 +636,14 @@ mod tests {
 	fn can_decode_raw_transaction() {
 		let bytes = hex!("f901e48080831000008080b90196608060405234801561001057600080fd5b50336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055507fc68045c3c562488255b55aa2c4c7849de001859ff0d8a36a75c2d5ed80100fb660405180806020018281038252600d8152602001807f48656c6c6f2c20776f726c64210000000000000000000000000000000000000081525060200191505060405180910390a160cf806100c76000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80638da5cb5b14602d575b600080fd5b60336075565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff168156fea265627a7a72315820fae816ad954005c42bea7bc7cb5b19f7fd5d3a250715ca2023275c9ca7ce644064736f6c634300050f003278a04cab43609092a99cf095d458b61b47189d1bbab64baed10a0fd7b7d2de2eb960a011ab1bcda76dfed5e733219beb83789f9887b2a7b2e61759c7c90f7d40403201");
 
-		rlp::decode::<Transaction>(&bytes).unwrap();
+		rlp::decode::<TransactionV0>(&bytes).unwrap();
+		rlp::decode::<TransactionV1>(&bytes).unwrap();
+		rlp::decode::<TransactionV2>(&bytes).unwrap();
 	}
 
 	#[test]
 	fn transaction_v0() {
-		let tx = Transaction::V0(TransactionV0 {
+		let tx = TransactionV0 {
 			nonce: 12.into(),
 			gas_price: 20_000_000_000_u64.into(),
 			gas_limit: 21000.into(),
@@ -651,14 +653,14 @@ mod tests {
 			value: U256::from(10) * 1_000_000_000 * 1_000_000_000,
 			input: hex!("a9059cbb000000000213ed0f886efd100b67c7e4ec0a85a7d20dc971600000000000000000000015af1d78b58c4000").into(),
 			signature: TransactionSignature::new(38, hex!("be67e0a07db67da8d446f76add590e54b6e92cb6b8f9835aeb67540579a27717").into(), hex!("2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7bd718").into()).unwrap(),
-		});
+		};
 
-		assert_eq!(tx, rlp::decode::<Transaction>(&rlp::encode(&tx)).unwrap());
+		assert_eq!(tx, rlp::decode::<TransactionV0>(&rlp::encode(&tx)).unwrap());
 	}
 
 	#[test]
 	fn transaction_v1() {
-		let tx = Transaction::V1(TransactionV1 {
+		let tx = TransactionV1::EIP2930(EIP2930Transaction {
 			chain_id: 5,
 			nonce: 7.into(),
 			gas_price: 30_000_000_000_u64.into(),
@@ -688,12 +690,12 @@ mod tests {
 			s: hex!("5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094").into(),
 		});
 
-		assert_eq!(tx, rlp::decode(&rlp::encode(&tx)).unwrap());
+		assert_eq!(tx, rlp::decode::<TransactionV1>(&rlp::encode(&tx)).unwrap());
 	}
 
 	#[test]
 	fn transaction_v2() {
-		let tx = Transaction::V2(TransactionV2 {
+		let tx = TransactionV2::EIP1559(EIP1559Transaction {
 			chain_id: 5,
 			nonce: 7.into(),
 			max_priority_fee_per_gas: 10_000_000_000_u64.into(),
@@ -724,6 +726,6 @@ mod tests {
 			s: hex!("5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094").into(),
 		});
 
-		assert_eq!(tx, rlp::decode(&rlp::encode(&tx)).unwrap());
+		assert_eq!(tx, rlp::decode::<TransactionV2>(&rlp::encode(&tx)).unwrap());
 	}
 }


### PR DESCRIPTION
This makes the type dependency less confusing and makes sure everything is exported.