### PR TITLE
Add support for scale-info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 ethereum-types = { version = "0.12", default-features = false, features = [
-	"rlp",
+	"rlp", "scale-info",
 ] }
 rlp = { version = "0.5", default-features = false }
 codec = { package = "parity-scale-codec", optional = true, version = "2.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ sha3 = { version = "0.9", default-features = false }
 triehash = { version = "0.8", default-features = false }
 hash256-std-hasher = { version = "0.15", default-features = false }
 hash-db = { version = "0.15", default-features = false }
+scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8"
@@ -44,6 +45,7 @@ std = [
 	"triehash/std",
 	"hash256-std-hasher/std",
 	"hash-db/std",
+	"scale-info/std",
 ]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ hex-literal = "0.3"
 default = ["std"]
 with-codec = ["codec", "ethereum-types/codec"]
 with-serde = ["serde", "ethereum-types/serialize"]
+#TODO scale-info feature
 std = [
 	"ethereum-types/std",
 	"rlp/std",
@@ -50,3 +51,9 @@ std = [
 
 [workspace]
 members = []
+
+# Use scale-info compatible crate that I hacked together.
+[patch.crates-io]
+ethereum-types = { git = "https://github.com/purestake/parity-common", branch = "joshy-scale-info-ethereum"}
+rlp = { git = "https://github.com/purestake/parity-common", branch = "joshy-scale-info-ethereum"}
+rlp-derive = { git = "https://github.com/purestake/parity-common", branch = "joshy-scale-info-ethereum"}

--- a/src/log.rs
+++ b/src/log.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use ethereum_types::{H160, H256};
 use rlp_derive::{RlpDecodable, RlpEncodable};
 
-#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, RlpEncodable, RlpDecodable, scale_info::TypeInfo)]
 #[cfg_attr(feature = "with-codec", derive(codec::Encode, codec::Decode))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Log {


### PR DESCRIPTION
cc @ascjones

@sorpaas I wonder if you want `scale-info` to be a feature? Or maybe part of the `with-codec` feature?