### PR TITLE
Fix EIP7702 RPC response format

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -131,10 +131,12 @@ mod tests {
 	};
 	use ethereum_types::{H160, H256, U256};
 
-	const ONE: H256 = H256([
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		0, 1,
-	]);
+	fn one() -> U256 {
+		U256::from_big_endian(&[
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 1,
+		])
+	}
 
 	#[test]
 	fn block_v3_with_eip7702_transaction() {
@@ -155,11 +157,11 @@ mod tests {
 				nonce: U256::zero(),
 				signature: eip2930::MalleableTransactionSignature {
 					odd_y_parity: false,
-					r: ONE,
-					s: ONE,
+					r: one(),
+					s: one(),
 				},
 			}],
-			signature: eip2930::TransactionSignature::new(false, ONE, ONE).unwrap(),
+			signature: eip2930::TransactionSignature::new(false, one(), one()).unwrap(),
 		});
 
 		// Create a block with the EIP-7702 transaction
@@ -213,7 +215,7 @@ mod tests {
 			value: U256::zero(),
 			input: vec![],
 			access_list: vec![],
-			signature: eip2930::TransactionSignature::new(false, ONE, ONE).unwrap(),
+			signature: eip2930::TransactionSignature::new(false, one(), one()).unwrap(),
 		});
 
 		let partial_header = PartialHeader {

--- a/src/transaction/eip1559.rs
+++ b/src/transaction/eip1559.rs
@@ -67,8 +67,8 @@ impl rlp::Encodable for EIP1559Transaction {
 		s.append(&self.input);
 		s.append_list(&self.access_list);
 		s.append(&self.signature.odd_y_parity());
-		s.append(&U256::from_big_endian(&self.signature.r()[..]));
-		s.append(&U256::from_big_endian(&self.signature.s()[..]));
+		s.append(self.signature.r());
+		s.append(self.signature.s());
 	}
 }
 
@@ -90,8 +90,8 @@ impl rlp::Decodable for EIP1559Transaction {
 			access_list: rlp.list_at(8)?,
 			signature: {
 				let odd_y_parity = rlp.val_at(9)?;
-				let r = H256::from(rlp.val_at::<U256>(10)?.to_big_endian());
-				let s = H256::from(rlp.val_at::<U256>(11)?.to_big_endian());
+				let r = rlp.val_at::<U256>(10)?;
+				let s = rlp.val_at::<U256>(11)?;
 				TransactionSignature::new(odd_y_parity, r, s)
 					.ok_or(DecoderError::Custom("Invalid transaction signature format"))?
 			},

--- a/src/transaction/eip2930.rs
+++ b/src/transaction/eip2930.rs
@@ -29,8 +29,8 @@ pub struct MalleableTransactionSignature {
 		serde(rename = "yParity", with = "crate::util::hex_bool")
 	)]
 	pub odd_y_parity: bool,
-	pub r: H256,
-	pub s: H256,
+	pub r: U256,
+	pub s: U256,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -45,25 +45,26 @@ pub struct MalleableTransactionSignature {
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize))]
 pub struct TransactionSignature {
 	odd_y_parity: bool,
-	r: H256,
-	s: H256,
+	r: U256,
+	s: U256,
 }
 
 impl TransactionSignature {
 	#[must_use]
-	pub fn new(odd_y_parity: bool, r: H256, s: H256) -> Option<Self> {
-		const LOWER: H256 = H256([
+	pub fn new(odd_y_parity: bool, r: U256, s: U256) -> Option<Self> {
+		let lower = U256::from_big_endian(&[
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x01,
 		]);
-		const UPPER: H256 = H256([
+
+		let upper = U256::from_big_endian(&[
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
 			0xd0, 0x36, 0x41, 0x41,
 		]);
 
-		let is_valid = r < UPPER && r >= LOWER && s < UPPER && s >= LOWER;
+		let is_valid = r < upper && r >= lower && s < upper && s >= lower;
 
 		if is_valid {
 			Some(Self { odd_y_parity, r, s })
@@ -78,24 +79,24 @@ impl TransactionSignature {
 	}
 
 	#[must_use]
-	pub fn r(&self) -> &H256 {
+	pub fn r(&self) -> &U256 {
 		&self.r
 	}
 
 	#[must_use]
-	pub fn s(&self) -> &H256 {
+	pub fn s(&self) -> &U256 {
 		&self.s
 	}
 
 	#[must_use]
 	pub fn is_low_s(&self) -> bool {
-		const LOWER: H256 = H256([
+		let lower = U256::from_big_endian(&[
 			0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xff, 0x5d, 0x57, 0x6e, 0x73, 0x57, 0xa4, 0x50, 0x1d, 0xdf, 0xe9, 0x2f, 0x46,
 			0x68, 0x1b, 0x20, 0xa0,
 		]);
 
-		self.s <= LOWER
+		self.s <= lower
 	}
 }
 
@@ -217,8 +218,8 @@ impl rlp::Encodable for EIP2930Transaction {
 		s.append(&self.input);
 		s.append_list(&self.access_list);
 		s.append(&self.signature.odd_y_parity());
-		s.append(&U256::from_big_endian(&self.signature.r()[..]));
-		s.append(&U256::from_big_endian(&self.signature.s()[..]));
+		s.append(self.signature.r());
+		s.append(self.signature.s());
 	}
 }
 
@@ -239,8 +240,8 @@ impl rlp::Decodable for EIP2930Transaction {
 			access_list: rlp.list_at(7)?,
 			signature: {
 				let odd_y_parity = rlp.val_at(8)?;
-				let r = H256::from(rlp.val_at::<U256>(9)?.to_big_endian());
-				let s = H256::from(rlp.val_at::<U256>(10)?.to_big_endian());
+				let r = rlp.val_at::<U256>(9)?;
+				let s = rlp.val_at::<U256>(10)?;
 				TransactionSignature::new(odd_y_parity, r, s)
 					.ok_or(DecoderError::Custom("Invalid transaction signature format"))?
 			},

--- a/src/transaction/eip2930.rs
+++ b/src/transaction/eip2930.rs
@@ -18,8 +18,16 @@ pub use super::legacy::TransactionAction;
 		scale_codec::DecodeWithMemTracking
 	)
 )]
-#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+	feature = "with-serde",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "camelCase")
+)]
 pub struct MalleableTransactionSignature {
+	#[cfg_attr(
+		feature = "with-serde",
+		serde(rename = "yParity", with = "crate::util::hex_bool")
+	)]
 	pub odd_y_parity: bool,
 	pub r: H256,
 	pub s: H256,

--- a/src/transaction/eip7702.rs
+++ b/src/transaction/eip7702.rs
@@ -62,8 +62,8 @@ impl rlp::Encodable for AuthorizationListItem {
 		s.append(&self.address);
 		s.append(&self.nonce);
 		s.append(&self.signature.odd_y_parity);
-		s.append(&U256::from_big_endian(&self.signature.r[..]));
-		s.append(&U256::from_big_endian(&self.signature.s[..]));
+		s.append(&self.signature.r);
+		s.append(&self.signature.s);
 	}
 }
 
@@ -79,8 +79,8 @@ impl rlp::Decodable for AuthorizationListItem {
 			nonce: rlp.val_at(2)?,
 			signature: {
 				let odd_y_parity = rlp.val_at(3)?;
-				let r = H256::from(rlp.val_at::<U256>(4)?.to_big_endian());
-				let s = H256::from(rlp.val_at::<U256>(5)?.to_big_endian());
+				let r = rlp.val_at::<U256>(4)?;
+				let s = rlp.val_at::<U256>(5)?;
 				MalleableTransactionSignature { odd_y_parity, r, s }
 			},
 		})
@@ -111,8 +111,8 @@ impl AuthorizationListItem {
 
 		// Create signature from r and s components
 		let mut signature_bytes = [0u8; 64];
-		signature_bytes[0..32].copy_from_slice(&sigv.r()[..]);
-		signature_bytes[32..64].copy_from_slice(&sigv.s()[..]);
+		signature_bytes[0..32].copy_from_slice(&sigv.r().to_big_endian());
+		signature_bytes[32..64].copy_from_slice(&sigv.s().to_big_endian());
 
 		// Create the signature and recovery ID
 		let signature = Signature::from_bytes(&signature_bytes.into())
@@ -235,8 +235,8 @@ impl rlp::Encodable for EIP7702Transaction {
 		s.append_list(&self.access_list);
 		s.append_list(&self.authorization_list);
 		s.append(&self.signature.odd_y_parity());
-		s.append(&U256::from_big_endian(&self.signature.r()[..]));
-		s.append(&U256::from_big_endian(&self.signature.s()[..]));
+		s.append(self.signature.r());
+		s.append(self.signature.s());
 	}
 }
 
@@ -259,8 +259,8 @@ impl rlp::Decodable for EIP7702Transaction {
 			authorization_list: rlp.list_at(9)?,
 			signature: {
 				let odd_y_parity = rlp.val_at(10)?;
-				let r = H256::from(rlp.val_at::<U256>(11)?.to_big_endian());
-				let s = H256::from(rlp.val_at::<U256>(12)?.to_big_endian());
+				let r = rlp.val_at::<U256>(11)?;
+				let s = rlp.val_at::<U256>(12)?;
 				TransactionSignature::new(odd_y_parity, r, s)
 					.ok_or(DecoderError::Custom("Invalid transaction signature format"))?
 			},
@@ -357,8 +357,8 @@ mod tests {
 
 		// Extract signature components
 		let signature_bytes = signature.to_bytes();
-		let r = H256::from_slice(&signature_bytes[0..32]);
-		let s = H256::from_slice(&signature_bytes[32..64]);
+		let r = U256::from_big_endian(&signature_bytes[0..32]);
+		let s = U256::from_big_endian(&signature_bytes[32..64]);
 		let y_parity = recovery_id.is_y_odd();
 
 		// Create AuthorizationListItem with real signature
@@ -401,8 +401,8 @@ mod tests {
 		// Test with invalid signature components (zero values are invalid in ECDSA)
 		assert!(TransactionSignature::new(
 			false,
-			H256::zero(), // Invalid r value (r cannot be zero)
-			H256::zero(), // Invalid s value (s cannot be zero)
+			U256::zero(), // Invalid r value (r cannot be zero)
+			U256::zero(), // Invalid s value (s cannot be zero)
 		)
 		.is_none());
 
@@ -411,8 +411,8 @@ mod tests {
 		assert!(TransactionSignature::new(
 			false,
 			// Use maximum possible values which exceed the curve order
-			H256::from_slice(&[0xFF; 32]),
-			H256::from_slice(&[0xFF; 32]),
+			U256::from_big_endian(&[0xFF; 32]),
+			U256::from_big_endian(&[0xFF; 32]),
 		)
 		.is_none());
 	}

--- a/src/transaction/eip7702.rs
+++ b/src/transaction/eip7702.rs
@@ -41,11 +41,17 @@ pub const AUTHORIZATION_MAGIC: u8 = 0x05;
 		scale_info::TypeInfo
 	)
 )]
-#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+	feature = "with-serde",
+	derive(serde::Serialize, serde::Deserialize),
+	serde(rename_all = "camelCase")
+)]
 pub struct AuthorizationListItem {
+	#[cfg_attr(feature = "with-serde", serde(with = "crate::util::hex_u64"))]
 	pub chain_id: u64,
 	pub address: Address,
 	pub nonce: U256,
+	#[cfg_attr(feature = "with-serde", serde(flatten))]
 	pub signature: MalleableTransactionSignature,
 }
 

--- a/src/transaction/legacy.rs
+++ b/src/transaction/legacy.rs
@@ -94,26 +94,27 @@ impl TransactionRecoveryId {
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize))]
 pub struct TransactionSignature {
 	v: TransactionRecoveryId,
-	r: H256,
-	s: H256,
+	r: U256,
+	s: U256,
 }
 
 impl TransactionSignature {
 	#[must_use]
-	pub fn new(v: u64, r: H256, s: H256) -> Option<Self> {
-		const LOWER: H256 = H256([
+	pub fn new(v: u64, r: U256, s: U256) -> Option<Self> {
+		let lower = U256::from_big_endian(&[
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x01,
 		]);
-		const UPPER: H256 = H256([
+
+		let upper = U256::from_big_endian(&[
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
 			0xd0, 0x36, 0x41, 0x41,
 		]);
 
 		let v = TransactionRecoveryId(v);
-		let is_valid = v.standard() <= 1 && r < UPPER && r >= LOWER && s < UPPER && s >= LOWER;
+		let is_valid = v.standard() <= 1 && r < upper && r >= lower && s < upper && s >= lower;
 
 		if is_valid {
 			Some(Self { v, r, s })
@@ -138,24 +139,24 @@ impl TransactionSignature {
 	}
 
 	#[must_use]
-	pub fn r(&self) -> &H256 {
+	pub fn r(&self) -> &U256 {
 		&self.r
 	}
 
 	#[must_use]
-	pub fn s(&self) -> &H256 {
+	pub fn s(&self) -> &U256 {
 		&self.s
 	}
 
 	#[must_use]
 	pub fn is_low_s(&self) -> bool {
-		const LOWER: H256 = H256([
+		let lower = U256::from_big_endian(&[
 			0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xff, 0x5d, 0x57, 0x6e, 0x73, 0x57, 0xa4, 0x50, 0x1d, 0xdf, 0xe9, 0x2f, 0x46,
 			0x68, 0x1b, 0x20, 0xa0,
 		]);
 
-		self.s <= LOWER
+		self.s <= lower
 	}
 }
 
@@ -185,8 +186,8 @@ impl scale_codec::Decode for TransactionSignature {
 #[derive(serde::Deserialize)]
 struct TransactionSignatureUnchecked {
 	v: u64,
-	r: H256,
-	s: H256,
+	r: U256,
+	s: U256,
 }
 
 #[cfg(feature = "with-serde")]
@@ -253,8 +254,8 @@ impl rlp::Encodable for LegacyTransaction {
 		s.append(&self.value);
 		s.append(&self.input);
 		s.append(&self.signature.v.0);
-		s.append(&U256::from_big_endian(&self.signature.r[..]));
-		s.append(&U256::from_big_endian(&self.signature.s[..]));
+		s.append(&self.signature.r);
+		s.append(&self.signature.s);
 	}
 }
 
@@ -265,8 +266,8 @@ impl rlp::Decodable for LegacyTransaction {
 		}
 
 		let v = rlp.val_at(6)?;
-		let r = H256::from(rlp.val_at::<U256>(7)?.to_big_endian());
-		let s = H256::from(rlp.val_at::<U256>(8)?.to_big_endian());
+		let r = rlp.val_at::<U256>(7)?;
+		let s = rlp.val_at::<U256>(8)?;
 		let signature = TransactionSignature::new(v, r, s)
 			.ok_or(DecoderError::Custom("Invalid transaction signature format"))?;
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -394,8 +394,12 @@ mod tests {
 			],
 			signature: eip2930::TransactionSignature::new(
 				false,
-				hex!("36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0").into(),
-				hex!("5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094").into(),
+				U256::from_big_endian(&hex!(
+					"36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0"
+				)),
+				U256::from_big_endian(&hex!(
+					"5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094"
+				)),
 			)
 			.unwrap(),
 		});
@@ -436,8 +440,12 @@ mod tests {
 			],
 			signature: eip2930::TransactionSignature::new(
 				false,
-				hex!("36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0").into(),
-				hex!("5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094").into(),
+				U256::from_big_endian(&hex!(
+					"36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0"
+				)),
+				U256::from_big_endian(&hex!(
+					"5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094"
+				)),
 			)
 			.unwrap(),
 		});
@@ -474,16 +482,22 @@ mod tests {
 				nonce: 1.into(),
 				signature: eip2930::MalleableTransactionSignature {
 					odd_y_parity: false,
-					r: hex!("36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0")
-						.into(),
-					s: hex!("5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094")
-						.into(),
+					r: U256::from_big_endian(&hex!(
+						"36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0"
+					)),
+					s: U256::from_big_endian(&hex!(
+						"5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094"
+					)),
 				},
 			}],
 			signature: eip2930::TransactionSignature::new(
 				false,
-				hex!("36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0").into(),
-				hex!("5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094").into(),
+				U256::from_big_endian(&hex!(
+					"36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0"
+				)),
+				U256::from_big_endian(&hex!(
+					"5edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094"
+				)),
 			)
 			.unwrap(),
 		});

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -356,7 +356,7 @@ mod tests {
 			),
 			value: U256::from(10) * 1_000_000_000 * 1_000_000_000,
 			input: hex!("a9059cbb000000000213ed0f886efd100b67c7e4ec0a85a7d20dc971600000000000000000000015af1d78b58c4000").into(),
-			signature: legacy::TransactionSignature::new(38, hex!("be67e0a07db67da8d446f76add590e54b6e92cb6b8f9835aeb67540579a27717").into(), hex!("2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7bd718").into()).unwrap(),
+			signature: legacy::TransactionSignature::new(38, U256::from_big_endian(&hex!("be67e0a07db67da8d446f76add590e54b6e92cb6b8f9835aeb67540579a27717")), U256::from_big_endian(&hex!("2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7bd718"))).unwrap(),
 		};
 
 		assert_eq!(

--- a/src/util.rs
+++ b/src/util.rs
@@ -163,6 +163,63 @@ where
 	)
 }
 
+#[cfg(feature = "with-serde")]
+pub mod hex_u64 {
+	use serde::de::Error;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	/// Serialize a u64 as a hex string with 0x prefix
+	pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let hex_str = alloc::format!("0x{:x}", value);
+		serializer.serialize_str(&hex_str)
+	}
+
+	/// Deserialize a hex string into a u64
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let s: &str = Deserialize::deserialize(deserializer)?;
+
+		// Remove optional "0x" prefix
+		let s = s.strip_prefix("0x").unwrap_or(s);
+
+		u64::from_str_radix(s, 16).map_err(D::Error::custom)
+	}
+}
+
+#[cfg(feature = "with-serde")]
+pub mod hex_bool {
+	use ethereum_types::U64;
+	use serde::de::Error;
+	use serde::{Deserialize, Deserializer, Serializer};
+
+	pub fn serialize<S>(b: &bool, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let hex_str = alloc::format!("0x{:x}", b.clone() as u8);
+		serializer.serialize_str(&hex_str)
+	}
+
+	pub fn deserialize<'de, D>(deserializer: D) -> Result<bool, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let s: &str = Deserialize::deserialize(deserializer)?;
+
+		// Remove optional "0x" prefix
+		let s = s.strip_prefix("0x").unwrap_or(s);
+
+		u64::from_str_radix(s, 16)
+			.map(|v| v == 1)
+			.map_err(D::Error::custom)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use ethereum_types::H256;


### PR DESCRIPTION
Update the field names, casing, and types used in the `authorization_list` returned by the RPC, to match the expected format.

It also changes the types of the `r` and `s` signature components from `H256` to `U256`. This helps strip leading zeroes during serialization in a clean and consistent way, aligning frontier output with both **reth** and **geth**.

---

### Why this is needed

Right now, calling something like `cast block` against our RPC gives a different structure than what clients expect.

For example, here's what a **geth** RPC returns:

```json
{
   "authorizationList":[
      {
          "chainId":"0xaa36a7",
          "address":"0x8d101f00e7b804b69e67196da9a700ee1b0cb95e",
          "nonce":"0x42",
          "yParity":"0x1",
          "r":"0xe314f379c01725882ba1711ab879430caacb9b0c3b2c82fef6d6847ed05d7ded",
          "s":"0x6b253af0ef948b93a7aecb4406f40d352ed2b8ff536fcecd912c21b68f9d1144"
      }
   ]
}
```

But **frontier** currently returns:

```json
{
   "authorizationList":[
      {
         "address":"0xd0e0531c7ae2d078e3b69dddfe22a99b42cc0103",
         "chain_id":1287,
         "nonce":"0x0",
         "signature":{
            "odd_y_parity":false,
            "r":"0xcfb9d7d69a40794807a32aa6795a696284c455d541883dcbd2f8529d05812365",
            "s":"0x0631093625f29f2a6d540e3db4d90d33b29e63c22801bbfdd478579220df1da4"
         }
      }
   ]
}
```

---

### Why update it here?

Ideally this would be handled upstream in the **frontier** codebase. But since:

* Frontier heavily depend on Ethereum types
* The change should not break any on-chain storage
* Fixes compatibility with widely used tooling

…it seems reasonable to handle the fix here for now.