### PR TITLE
Add encoded length methods to transactions

### DIFF
--- a/src/enveloped.rs
+++ b/src/enveloped.rs
@@ -29,11 +29,25 @@ pub trait EnvelopedEncodable {
 		out
 	}
 
+	/// Returns the length of the encoded transaction.
+	///
+	/// This is the EIP-2718 encoded length: type_id (1 byte for typed txs) + RLP payload.
+	/// Matches geth's `tx.Size()` and reth/alloy's `encoded_length()`.
+	fn encoded_len(&self) -> usize {
+		let type_id_len = if self.type_id().is_some() { 1 } else { 0 };
+		type_id_len + self.payload_len()
+	}
+
 	/// Type Id of the transaction.
 	fn type_id(&self) -> Option<u8>;
 
 	/// Encode inner payload.
 	fn encode_payload(&self) -> BytesMut;
+
+	/// Returns the length of the RLP-encoded payload without the type byte.
+	fn payload_len(&self) -> usize {
+		self.encode_payload().len()
+	}
 }
 
 /// Decodable typed transactions.

--- a/src/transaction/eip1559.rs
+++ b/src/transaction/eip1559.rs
@@ -120,6 +120,11 @@ impl EIP1559TransactionMessage {
 		out[1..].copy_from_slice(&encoded);
 		H256::from_slice(Keccak256::digest(&out).as_ref())
 	}
+
+	/// Returns the RLP-encoded length of this unsigned message.
+	pub fn encoded_len(&self) -> usize {
+		rlp::encode(self).len()
+	}
 }
 
 impl rlp::Encodable for EIP1559TransactionMessage {

--- a/src/transaction/eip2930.rs
+++ b/src/transaction/eip2930.rs
@@ -245,6 +245,11 @@ impl EIP2930TransactionMessage {
 		out[1..].copy_from_slice(&encoded);
 		H256::from_slice(Keccak256::digest(&out).as_ref())
 	}
+
+	/// Returns the RLP-encoded length of this unsigned message.
+	pub fn encoded_len(&self) -> usize {
+		rlp::encode(self).len()
+	}
 }
 
 impl rlp::Encodable for EIP2930TransactionMessage {

--- a/src/transaction/eip7702.rs
+++ b/src/transaction/eip7702.rs
@@ -284,6 +284,11 @@ impl EIP7702TransactionMessage {
 		out[1..].copy_from_slice(&encoded);
 		H256::from_slice(Keccak256::digest(&out).as_ref())
 	}
+
+	/// Returns the RLP-encoded length of this unsigned message.
+	pub fn encoded_len(&self) -> usize {
+		rlp::encode(self).len()
+	}
 }
 
 impl rlp::Encodable for EIP7702TransactionMessage {

--- a/src/transaction/legacy.rs
+++ b/src/transaction/legacy.rs
@@ -283,6 +283,11 @@ impl LegacyTransactionMessage {
 	pub fn hash(&self) -> H256 {
 		H256::from_slice(Keccak256::digest(rlp::encode(self)).as_ref())
 	}
+
+	/// Returns the RLP-encoded length of this unsigned message.
+	pub fn encoded_len(&self) -> usize {
+		rlp::encode(self).len()
+	}
 }
 
 impl rlp::Encodable for LegacyTransactionMessage {


### PR DESCRIPTION
## Summary

Add `encoded_len()` and `payload_len()` methods to compute transaction sizes without full encoding. This enables transaction size validation for DoS protection, matching reth/alloy's approach.

## Motivation

Transaction pools need to enforce size limits for performance reasons and to prevent DoS attacks. Reth enforces a default maximum of [128 KB per transaction](https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/constants.rs#L10-L12) and [validates transactions](https://github.com/paradigmxyz/reth/blob/main/crates/transaction-pool/src/validate/eth.rs#L358-L362).

Alloy provides similar methods on [transaction envelopes](https://github.com/alloy-rs/alloy/blob/main/crates/consensus/src/transaction/envelope.rs) for this purpose.
